### PR TITLE
[Feature] Tool for inferring avg bandwidth utilization via calls to `cudaMemcpy`

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,5 +72,30 @@ GPUprobe cudatrace utility
         0x626693de7b80: 1000 launches
         0x626693de7c60: 1000 launches
 ========================
+```
 
+## Bandwidth utilization utility
+
+In this sample output, we infer the average bandwidth utilization of calls to
+`cudaMemcpy`, a well as the direction of the transfers and their durations.
+
+```
+GPUprobe bandwidth_util utility
+========================
+
+
+Traced 1 cudaMemcpy calls
+        H2D 3045740550.87548 bytes/sec for 0.00263 secs
+========================
+
+Traced 2 cudaMemcpy calls
+        H2D 2981869117.56429 bytes/sec for 0.00268 secs
+        D2H 3039108386.38160 bytes/sec for 0.00263 secs
+========================
+```
+
+This is computed naively with
+
+```
+throughput = count / (end - start)
 ```

--- a/src/bpf/Makefile
+++ b/src/bpf/Makefile
@@ -4,7 +4,7 @@ ARCH := x86
 
 CFLAGS := -O2 -g --target=bpf -Wno-compare-distinct-pointer-types
 CFLAGS += -D__TARGET_ARCH_$(ARCH)
-INCLUDES := -Iinclude -I. -I../../libbpf/src/root/usr/include
+INCLUDES := -Iinclude -I. -I../../../libbpf/src/root/usr/include
 
 all: gpuprobe.bpf.o gpuprobe.skel.h
 

--- a/src/bpf/gpuprobe.bpf.c
+++ b/src/bpf/gpuprobe.bpf.c
@@ -182,4 +182,111 @@ int trace_cuda_launch_kernel(struct pt_regs *ctx)
 	return 0;
 }
 
+
+/**
+ * redefinition of `enum cudaMemcpyKind` in driver_types.h.
+ */
+enum memcpy_kind {
+	D2D = 0,	// device to device
+	D2H = 1,	// device to host
+	H2D = 2,	// host to device
+	H2H = 3,	// host to host
+	DEFAULT = 4, // inferred from pointer type at runtime
+};
+
+struct cuda_memcpy {
+	__u64 start_time;
+	__u64 end_time;
+	void* dst;
+	void* src;
+	size_t count;
+	enum memcpy_kind kind;
+};
+
+/**
+ * Maps a pid to an information on an incomplete cudaMemcpy call. This is 
+ * needed because we cannot access the input arguments inside of the uretprobe.
+ */
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__type(key, __u32);
+	__type(value, struct cuda_memcpy);
+	__uint(max_entries, 10240);
+} pid_to_memcpy SEC(".maps");
+
+/**
+ * Queue of successful cudaMemcpy calls to be processed from userspace.
+ */
+struct {
+	__uint(type, BPF_MAP_TYPE_QUEUE);
+	__uint(key_size, 0);
+	__uint(value_size, sizeof(struct cuda_memcpy));
+	__uint(max_entries, 10240);
+} successful_cuda_memcpy_q SEC(".maps");
+
+/**
+ * This function exhibits synchronous behavior in MOST cases as specified by
+ * Nvidia documentation. It is under the assumption that this call is 
+ * synchronous that we compute the average memory bandwidth of a transfer as:
+ *		avg_throughput = count /  (end - start)
+ */
+SEC("uprobe/cudaMemcpy")
+int trace_cuda_memcpy(struct pt_regs *ctx)
+{
+	void* dst = (void*) PT_REGS_PARM1(ctx);
+	void *src = (void*) PT_REGS_PARM2(ctx);
+	size_t count = PT_REGS_PARM3(ctx);
+	enum memcpy_kind kind = PT_REGS_PARM4(ctx);
+	__u32 pid = (__u32)bpf_get_current_pid_tgid();
+
+	/* no host-side synchronization is performed in the D2D case - as a result,
+	 * we cannot compute average throughput using information available from
+	 * this uprobe. If the DEFAULT argument is passed, we cannot make any 
+	 * assumption on the direction of the transfer */
+	if (kind == D2D || kind == DEFAULT)
+		return 0;
+
+	struct cuda_memcpy in_progress_memcpy = {
+		.start_time = bpf_ktime_get_ns(),
+		.dst = dst,
+		.src = src,
+		.count = count,
+		.kind = kind
+	};
+
+	if (bpf_map_update_elem(&pid_to_memcpy, &pid, &in_progress_memcpy, 0)) {
+		return -1;
+	}
+
+	return 0;
+}
+
+SEC("uretprobe/cudaMemcpy")
+int trace_cuda_memcpy_ret(struct pt_regs *ctx)
+{
+	__u32 ret = PT_REGS_RC(ctx);
+	__u32 pid = (__u32)bpf_get_current_pid_tgid();
+	struct cuda_memcpy *exited_memcpy;
+
+	if (ret) {
+		return -1;
+	}
+
+	exited_memcpy = (struct cuda_memcpy *) bpf_map_lookup_elem(&pid_to_memcpy, &pid);
+	if (!exited_memcpy) {
+		return -1;
+	}
+
+	if (bpf_map_delete_elem(&pid_to_memcpy, &pid)) {
+		return -1;
+	}
+
+	exited_memcpy->end_time = bpf_ktime_get_ns();
+	if (bpf_map_push_elem(&successful_cuda_memcpy_q, exited_memcpy, 0)) {
+		return -1;
+	}
+
+	return 0;
+}
+
 char LICENSE[] SEC("license") = "GPL";

--- a/src/gpuprobe/gpuprobe_bandwidth_util.rs
+++ b/src/gpuprobe/gpuprobe_bandwidth_util.rs
@@ -87,6 +87,30 @@ impl CudaMemcpy {
         // 2. The byte array is at least as large as the struct
         unsafe { Some(std::ptr::read_unaligned(bytes.as_ptr() as *const Self)) }
     }
+
+    /// Returns a human readable version of the `kind` parameter passed to
+    /// `cudaMemcpy`
+    pub fn kind_to_str(&self) -> String {
+        match self.memcpy_kind {
+            0 => "H2H".to_string(),
+            1 => "H2D".to_string(),
+            2 => "D2H".to_string(),
+            3 => "D2D".to_string(),
+            4 => "DEF".to_string(),
+            _ => "INVALID KIND".to_string(),
+        }
+    }
+
+    pub fn compute_bandwidth_util(&self) -> Option<f64> {
+        if self.start_time >= self.end_time {
+            return None;
+        }
+
+        let delta = (self.end_time - self.start_time) as f64;
+        let nanos_per_second = 1e9;
+        let res = (self.count as f64) / delta * nanos_per_second;
+        Some(res)
+    }
 }
 
 impl std::fmt::Display for CudaMemcpy {

--- a/src/gpuprobe/gpuprobe_bandwidth_util.rs
+++ b/src/gpuprobe/gpuprobe_bandwidth_util.rs
@@ -1,0 +1,103 @@
+mod gpuprobe {
+    include!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/src/bpf/gpuprobe.skel.rs"
+    ));
+}
+
+use libbpf_rs::MapCore;
+
+use super::{Gpuprobe, GpuprobeError, DEFAULT_LINKS, LIBCUDART_PATH};
+
+impl Gpuprobe {
+    /// attaches uprobes for the bandwidth util program, or returns an error on
+    /// failure
+    pub fn attach_bandwidth_util_uprobes(&mut self) -> Result<(), GpuprobeError> {
+        let cuda_memcpy_uprobe_link = self
+            .skel
+            .progs
+            .trace_cuda_memcpy
+            .attach_uprobe(false, -1, LIBCUDART_PATH, 0x000000000006f150)
+            .map_err(|_| GpuprobeError::AttachError)?;
+
+        let cuda_memcpy_uretprobe_link = self
+            .skel
+            .progs
+            .trace_cuda_memcpy_ret
+            .attach_uprobe(true, -1, LIBCUDART_PATH, 0x000000000006f150)
+            .map_err(|_| GpuprobeError::AttachError)?;
+
+        let mut links = DEFAULT_LINKS;
+        links.trace_cuda_memcpy = Some(cuda_memcpy_uprobe_link);
+        links.trace_cuda_memcpy_ret = Some(cuda_memcpy_uretprobe_link);
+        self.links = links;
+        Ok(())
+    }
+
+    /// Copies all cudaMemcpy calls out of the queue and returns them as a Vec,
+    /// or returns a GpuProbeError on failure
+    pub fn consume_queue(&self) -> Result<Vec<CudaMemcpy>, GpuprobeError> {
+        let mut output: Vec<CudaMemcpy> = Vec::new();
+        let key: [u8; 0] = []; // key size must be zero for BPF_MAP_TYPE_QUEUE
+                               // `lookup_and_delete` calls.
+
+        while let Ok(opt) = self
+            .skel
+            .maps
+            .successful_cuda_memcpy_q
+            .lookup_and_delete(&key)
+        {
+            match opt {
+                Some(bytes) => match CudaMemcpy::from_bytes(&bytes) {
+                    Some(valid_instance) => output.push(valid_instance),
+                    None => {
+                        return Err(GpuprobeError::RuntimeError(
+                            "alloc conversion failure".to_string(),
+                        ))
+                    }
+                },
+                None => {
+                    return Ok(output);
+                }
+            }
+        }
+
+        Ok(output)
+    }
+}
+
+pub struct CudaMemcpy {
+    pub start_time: u64,
+    pub end_time: u64,
+    pub dst: *mut std::ffi::c_void,
+    pub src: *mut std::ffi::c_void,
+    pub count: u64,
+    pub memcpy_kind: u32,
+}
+
+impl CudaMemcpy {
+    /// Constructs a CudaMemcpy struct from a raw byte array and returns it, or
+    /// None if the byte array is invalid.
+    pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() < std::mem::size_of::<Self>() {
+            return None;
+        }
+        // This is safe if:
+        // 1. The byte array contains valid data for this struct
+        // 2. The byte array is at least as large as the struct
+        unsafe { Some(std::ptr::read_unaligned(bytes.as_ptr() as *const Self)) }
+    }
+}
+
+impl std::fmt::Display for CudaMemcpy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "{{")?;
+        writeln!(f, "\tstart_time: {}", self.start_time)?;
+        writeln!(f, "\tend_time: {}", self.end_time)?;
+        writeln!(f, "\tdst: {:p}", self.dst)?;
+        writeln!(f, "\tsrc: {:p}", self.dst)?;
+        writeln!(f, "\tcount: {}", self.count)?;
+        writeln!(f, "\tkind: {}", self.memcpy_kind)?;
+        writeln!(f, "}}")
+    }
+}

--- a/src/gpuprobe/gpuprobe_memleak.rs
+++ b/src/gpuprobe/gpuprobe_memleak.rs
@@ -2,8 +2,7 @@ use std::error::Error;
 
 use libbpf_rs::{MapCore, MapFlags};
 
-use super::gpuprobe::GpuprobeLinks;
-use super::{Gpuprobe, GpuprobeError};
+use super::{Gpuprobe, GpuprobeError, DEFAULT_LINKS};
 
 const LIBCUDART_PATH: &str = "/usr/local/cuda/lib64/libcudart.so";
 
@@ -40,13 +39,13 @@ impl Gpuprobe {
             .attach_uprobe(true, -1, LIBCUDART_PATH, 0x00000000000568c0)
             .map_err(|_| GpuprobeError::AttachError)?;
 
-        self.links = GpuprobeLinks {
-            trace_cuda_malloc: Some(cuda_malloc_uprobe_link),
-            trace_cuda_malloc_ret: Some(cuda_malloc_uretprobe_link),
-            trace_cuda_free: Some(cuda_free_uprobe_link),
-            trace_cuda_free_ret: Some(cuda_free_uretprobe_link),
-            trace_cuda_launch_kernel: None,
-        };
+        let mut links = DEFAULT_LINKS;
+        links.trace_cuda_malloc = Some(cuda_malloc_uprobe_link);
+        links.trace_cuda_malloc_ret = Some(cuda_malloc_uretprobe_link);
+        links.trace_cuda_free = Some(cuda_free_uprobe_link);
+        links.trace_cuda_free_ret = Some(cuda_free_uretprobe_link);
+        links.trace_cuda_launch_kernel = None;
+        self.links = links;
 
         Ok(())
     }

--- a/src/gpuprobe/mod.rs
+++ b/src/gpuprobe/mod.rs
@@ -1,3 +1,4 @@
+pub mod gpuprobe_bandwidth_util;
 pub mod gpuprobe_cudatrace;
 pub mod gpuprobe_memleak;
 
@@ -16,12 +17,24 @@ mod gpuprobe {
 }
 use gpuprobe::*;
 
+const LIBCUDART_PATH: &str = "/usr/local/cuda/lib64/libcudart.so";
+
 // TODO maybe consider using orobouros self-referential
 pub struct Gpuprobe {
     open_obj: Box<MaybeUninit<OpenObject>>,
     pub skel: GpuprobeSkel<'static>, // trust me bro
     links: GpuprobeLinks,
 }
+
+const DEFAULT_LINKS: GpuprobeLinks = GpuprobeLinks {
+    trace_cuda_malloc: None,
+    trace_cuda_malloc_ret: None,
+    trace_cuda_free: None,
+    trace_cuda_free_ret: None,
+    trace_cuda_launch_kernel: None,
+    trace_cuda_memcpy: None,
+    trace_cuda_memcpy_ret: None,
+};
 
 impl Gpuprobe {
     /// returns a new Gpuprobe or an initialization error on failure
@@ -38,13 +51,7 @@ impl Gpuprobe {
         Ok(Self {
             open_obj,
             skel,
-            links: GpuprobeLinks {
-                trace_cuda_malloc: None,
-                trace_cuda_malloc_ret: None,
-                trace_cuda_free: None,
-                trace_cuda_free_ret: None,
-                trace_cuda_launch_kernel: None,
-            },
+            links: DEFAULT_LINKS,
         })
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -140,11 +140,23 @@ fn bandwidth_util_prog() -> Result<(), gpuprobe::GpuprobeError> {
     loop {
         let calls = gpuprobe.consume_queue()?;
 
-        for call in calls {
-            println!("{}", call);
+        if calls.len() == 0 {
+            continue;
         }
 
+        println!("Traced {} cudaMemcpy calls", calls.len());
+        calls.iter().for_each(|c| {
+            let bandwidth_util = c.compute_bandwidth_util().unwrap_or(0.0);
+            let delta = (c.end_time - c.start_time) as f64 / 1e9;
+            println!(
+                "\t{} {:.5} bytes/sec for {:.5} secs",
+                c.kind_to_str(),
+                bandwidth_util,
+                delta
+            )
+        });
+
         println!("========================\n");
-        std::thread::sleep(std::time::Duration::from_secs(1));
+        std::thread::sleep(std::time::Duration::from_secs(5));
     }
 }


### PR DESCRIPTION
Adds option `--bandwidth-util` which infers the bandwidth utilization from calls to `cudaMemcpy`. Assumes total bandwidth utilization - should compute the sum across all GPUs in a multi-GPU environment.

