### PR TITLE
[feature] merge memleak, cudatrace, bandwidth util programs

### DIFF
--- a/src/gpuprobe/gpuprobe_bandwidth_util.rs
+++ b/src/gpuprobe/gpuprobe_bandwidth_util.rs
@@ -7,7 +7,7 @@ mod gpuprobe {
 
 use libbpf_rs::MapCore;
 
-use super::{Gpuprobe, GpuprobeError, DEFAULT_LINKS, LIBCUDART_PATH};
+use super::{Gpuprobe, GpuprobeError, LIBCUDART_PATH};
 
 impl Gpuprobe {
     /// attaches uprobes for the bandwidth util program, or returns an error on
@@ -27,10 +27,8 @@ impl Gpuprobe {
             .attach_uprobe(true, -1, LIBCUDART_PATH, 0x000000000006f150)
             .map_err(|_| GpuprobeError::AttachError)?;
 
-        let mut links = DEFAULT_LINKS;
-        links.trace_cuda_memcpy = Some(cuda_memcpy_uprobe_link);
-        links.trace_cuda_memcpy_ret = Some(cuda_memcpy_uretprobe_link);
-        self.links = links;
+        self.links.trace_cuda_memcpy = Some(cuda_memcpy_uprobe_link);
+        self.links.trace_cuda_memcpy_ret = Some(cuda_memcpy_uretprobe_link);
         Ok(())
     }
 

--- a/src/gpuprobe/gpuprobe_bandwidth_util.rs
+++ b/src/gpuprobe/gpuprobe_bandwidth_util.rs
@@ -56,9 +56,12 @@ impl Gpuprobe {
                     }
                 },
                 None => {
-                    return Ok(BandwidthUtilData {
-                        cuda_memcpys: output,
-                    });
+                    // This case suggests that a queue entry has no data. If
+                    // this occurs, it indicates a problem with the eBPF
+                    // program, so we return a runtime error.
+                    return Err(GpuprobeError::RuntimeError(
+                        "Found None data for key during lookup".to_string(),
+                    ));
                 }
             }
         }

--- a/src/gpuprobe/gpuprobe_bandwidth_util.rs
+++ b/src/gpuprobe/gpuprobe_bandwidth_util.rs
@@ -7,6 +7,7 @@ mod gpuprobe {
 
 use libbpf_rs::MapCore;
 
+use super::uprobe_data::BandwidthUtilData;
 use super::{Gpuprobe, GpuprobeError, LIBCUDART_PATH};
 
 impl Gpuprobe {
@@ -34,7 +35,7 @@ impl Gpuprobe {
 
     /// Copies all cudaMemcpy calls out of the queue and returns them as a Vec,
     /// or returns a GpuProbeError on failure
-    pub fn consume_queue(&self) -> Result<Vec<CudaMemcpy>, GpuprobeError> {
+    pub fn collect_data_bandwidth_util(&self) -> Result<BandwidthUtilData, GpuprobeError> {
         let mut output: Vec<CudaMemcpy> = Vec::new();
         let key: [u8; 0] = []; // key size must be zero for BPF_MAP_TYPE_QUEUE
                                // `lookup_and_delete` calls.
@@ -55,12 +56,16 @@ impl Gpuprobe {
                     }
                 },
                 None => {
-                    return Ok(output);
+                    return Ok(BandwidthUtilData {
+                        cuda_memcpys: output,
+                    });
                 }
             }
         }
 
-        Ok(output)
+        Ok(BandwidthUtilData {
+            cuda_memcpys: output,
+        })
     }
 }
 

--- a/src/gpuprobe/gpuprobe_cudatrace.rs
+++ b/src/gpuprobe/gpuprobe_cudatrace.rs
@@ -21,10 +21,7 @@ impl Gpuprobe {
             .attach_uprobe(false, -1, LIBCUDART_PATH, 0x0000000000074440)
             .map_err(|_| GpuprobeError::AttachError)?;
 
-        let mut links = DEFAULT_LINKS;
-        links.trace_cuda_launch_kernel = Some(cuda_launch_kernel_uprobe_link);
-        self.links = links;
-
+        self.links.trace_cuda_launch_kernel = Some(cuda_launch_kernel_uprobe_link);
         Ok(())
     }
 

--- a/src/gpuprobe/gpuprobe_cudatrace.rs
+++ b/src/gpuprobe/gpuprobe_cudatrace.rs
@@ -7,6 +7,7 @@ mod gpuprobe {
 
 use libbpf_rs::{MapCore, MapFlags};
 
+use super::uprobe_data::CudaTraceData;
 use super::{Gpuprobe, GpuprobeError, DEFAULT_LINKS, LIBCUDART_PATH};
 
 /// contains implementations for the cudatrace program
@@ -31,8 +32,8 @@ impl Gpuprobe {
     /// ASLR and other factors. We would ideally like to resolve which kernel
     /// is being launched by looking at the relative addresses inside of the
     /// cuda binary.
-    pub fn get_kernel_launch_frequencies(&self) -> Result<Vec<(u64, u64)>, GpuprobeError> {
-        Ok(self
+    pub fn collect_data_cudatrace(&self) -> Result<CudaTraceData, GpuprobeError> {
+        let hist: Vec<(u64, u64)> = self
             .skel
             .maps
             .kernel_calls_hist
@@ -49,6 +50,10 @@ impl Gpuprobe {
                 let call_count: [u8; 8] = call_count.try_into().expect("unable to convert count");
                 (u64::from_ne_bytes(key), u64::from_ne_bytes(call_count))
             })
-            .collect())
+            .collect();
+
+        Ok(CudaTraceData {
+            kernel_frequencies_histogram: hist,
+        })
     }
 }

--- a/src/gpuprobe/gpuprobe_memleak.rs
+++ b/src/gpuprobe/gpuprobe_memleak.rs
@@ -2,7 +2,7 @@ use std::error::Error;
 
 use libbpf_rs::{MapCore, MapFlags};
 
-use super::{Gpuprobe, GpuprobeError, DEFAULT_LINKS};
+use super::{Gpuprobe, GpuprobeError};
 
 const LIBCUDART_PATH: &str = "/usr/local/cuda/lib64/libcudart.so";
 
@@ -39,14 +39,10 @@ impl Gpuprobe {
             .attach_uprobe(true, -1, LIBCUDART_PATH, 0x00000000000568c0)
             .map_err(|_| GpuprobeError::AttachError)?;
 
-        let mut links = DEFAULT_LINKS;
-        links.trace_cuda_malloc = Some(cuda_malloc_uprobe_link);
-        links.trace_cuda_malloc_ret = Some(cuda_malloc_uretprobe_link);
-        links.trace_cuda_free = Some(cuda_free_uprobe_link);
-        links.trace_cuda_free_ret = Some(cuda_free_uretprobe_link);
-        links.trace_cuda_launch_kernel = None;
-        self.links = links;
-
+        self.links.trace_cuda_malloc = Some(cuda_malloc_uprobe_link);
+        self.links.trace_cuda_malloc_ret = Some(cuda_malloc_uretprobe_link);
+        self.links.trace_cuda_free = Some(cuda_free_uprobe_link);
+        self.links.trace_cuda_free_ret = Some(cuda_free_uretprobe_link);
         Ok(())
     }
 

--- a/src/gpuprobe/uprobe_data.rs
+++ b/src/gpuprobe/uprobe_data.rs
@@ -64,9 +64,10 @@ impl std::fmt::Display for CudaTraceData {
             num_launches,
             kernel_launches.len()
         )?;
-        kernel_launches.iter().for_each(|(addr, count)| {
-            writeln!(f, "\t0x{addr:x}: {count} launches");
-        });
+
+        for (addr, count) in kernel_launches.iter() {
+            writeln!(f, "\t0x{addr:x}: {count} launches")?;
+        }
         Ok(())
     }
 }
@@ -79,7 +80,7 @@ impl std::fmt::Display for BandwidthUtilData {
         }
 
         writeln!(f, "Traced {} cudaMemcpy calls", calls.len())?;
-        calls.iter().for_each(|c| {
+        for c in calls.iter() {
             let bandwidth_util = c.compute_bandwidth_util().unwrap_or(0.0);
             let delta = (c.end_time - c.start_time) as f64 / 1e9;
             writeln!(
@@ -88,8 +89,8 @@ impl std::fmt::Display for BandwidthUtilData {
                 c.kind_to_str(),
                 bandwidth_util,
                 delta
-            );
-        });
+            )?;
+        }
         Ok(())
     }
 }

--- a/src/gpuprobe/uprobe_data.rs
+++ b/src/gpuprobe/uprobe_data.rs
@@ -1,0 +1,95 @@
+use super::gpuprobe_bandwidth_util::CudaMemcpy;
+
+/// Defines the data collected by a uprobe / uretprobe
+pub trait UprobeData: std::fmt::Display /* add prometheus */ {}
+
+/// defines the data that is collected in a cycle of the memleak program
+pub struct MemleakData {
+    /// a Vec of `(addr, count)` where:
+    ///     - `addr` is the virtual address (on-device) of the allocation
+    ///     - `count` is the number of bytes associated to that allocation
+    pub outstanding_allocs: Vec<(u64, u64)>,
+}
+
+impl UprobeData for MemleakData {}
+
+/// defines the data that is collected in a cycle of the cudatrace program
+pub struct CudaTraceData {
+    /// a Vec of `(addr, count)` where:
+    ///     - `addr` is the function pointer to the launched cuda kernel
+    ///     - `count` is the number of times that that kernel was launched
+    pub kernel_frequencies_histogram: Vec<(u64, u64)>,
+}
+
+impl UprobeData for CudaTraceData {}
+
+/// defines the data that is collected in a cycle of the cudatrace program
+pub struct BandwidthUtilData {
+    /// a Vec of `CudaMemcpy` calls
+    pub cuda_memcpys: Vec<CudaMemcpy>,
+}
+
+impl UprobeData for BandwidthUtilData {}
+
+impl std::fmt::Display for MemleakData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let leaked_bytes = self
+            .outstanding_allocs
+            .iter()
+            .fold(0u64, |total, (_, size)| total + size);
+
+        writeln!(
+            f,
+            "{} bytes leaked from {} cuda memory allocation(s)",
+            leaked_bytes,
+            self.outstanding_allocs.len()
+        )?;
+
+        Ok(for (addr, size) in self.outstanding_allocs.iter() {
+            writeln!(f, "\t0x{addr:x}: {size} bytes")?;
+        })
+    }
+}
+
+impl std::fmt::Display for CudaTraceData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let kernel_launches = &self.kernel_frequencies_histogram;
+        let num_launches = kernel_launches
+            .iter()
+            .fold(0u64, |total, (_, count)| total + count);
+
+        writeln!(
+            f,
+            "{} `cudaLaunchKernel` calls for {} kernels",
+            num_launches,
+            kernel_launches.len()
+        )?;
+        kernel_launches.iter().for_each(|(addr, count)| {
+            writeln!(f, "\t0x{addr:x}: {count} launches");
+        });
+        Ok(())
+    }
+}
+
+impl std::fmt::Display for BandwidthUtilData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let calls = &self.cuda_memcpys;
+        if calls.len() == 0 {
+            return Ok(());
+        }
+
+        writeln!(f, "Traced {} cudaMemcpy calls", calls.len())?;
+        calls.iter().for_each(|c| {
+            let bandwidth_util = c.compute_bandwidth_util().unwrap_or(0.0);
+            let delta = (c.end_time - c.start_time) as f64 / 1e9;
+            writeln!(
+                f,
+                "\t{} {:.5} bytes/sec for {:.5} secs",
+                c.kind_to_str(),
+                bandwidth_util,
+                delta
+            );
+        });
+        Ok(())
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,162 +1,37 @@
 mod gpuprobe;
 
-use libbpf_rs::MapCore as _;
-use libbpf_rs::MapFlags;
-
 use clap::Parser;
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None, arg_required_else_help = true)]
 struct Args {
     /// Detects leaking calls to cudaMalloc from the CUDA runtime API.
-    #[arg(long, exclusive = true)]
+    #[arg(long, exclusive = false)]
     memleak: bool,
 
     /// Maintains a histogram on frequencies of cuda kernel launches.
-    #[arg(long, exclusive = true)]
+    #[arg(long, exclusive = false)]
     cudatrace: bool,
 
     /// Approximates bandwidth utilization of cudaMemcpy.
-    #[arg(long, exclusive = true)]
+    #[arg(long, exclusive = false)]
     bandwidth_util: bool,
 }
 
-const WELCOME_MEMLEAK_MSG: &str = r#"
-GPUprobe memleak utility
-========================
-
-"#;
-
-const WELCOME_CUDATRACE_MSG: &str = r#"
-GPUprobe cudatrace utility
-========================
-
-"#;
-
-const WELCOME_BANDWIDTH_UTIL_MSG: &str = r#"
-GPUprobe bandwidth_util utility
-========================
-
-"#;
-
 fn main() -> Result<(), gpuprobe::GpuprobeError> {
     let args = Args::parse();
-
-    if args.memleak {
-        return memleak_prog();
-    } else if args.cudatrace {
-        return cudatrace_prog();
-    } else if args.bandwidth_util {
-        return bandwidth_util_prog();
-    }
-
-    Ok(())
-}
-
-fn memleak_prog() -> Result<(), gpuprobe::GpuprobeError> {
-    println!("{WELCOME_MEMLEAK_MSG}");
-
-    let mut memleak = gpuprobe::Gpuprobe::new()?;
-    memleak.attach_memleak_uprobes()?;
-
-    let key0 = vec![0u8; 4];
-    loop {
-        let num_cuda_malloc_calls = memleak
-            .skel
-            .maps
-            .num_cuda_malloc_calls
-            .lookup(&key0, MapFlags::ANY)
-            .map(|v| match v {
-                None => {
-                    panic!("nothing found")
-                }
-                Some(num_mallocs) => {
-                    let array: [u8; 8] = num_mallocs.try_into().expect("unable to convert arr");
-                    u64::from_ne_bytes(array)
-                }
-            })
-            .expect("unable to perform map lookup");
-
-        println!(
-            "total number of `cudaMalloc` calls: {}",
-            num_cuda_malloc_calls
-        );
-
-        let oustanding_allocs = memleak
-            .get_outstanding_allocs()
-            .expect("unable to get allocations");
-
-        let leaked_bytes = oustanding_allocs
-            .iter()
-            .fold(0u64, |total, (_, size)| total + size);
-
-        println!(
-            "{} bytes leaked from {} cuda memory allocation(s)",
-            leaked_bytes,
-            oustanding_allocs.len()
-        );
-
-        oustanding_allocs.iter().for_each(|(addr, size)| {
-            println!("\t0x{addr:x}: {size} bytes");
-        });
-
-        println!("========================\n");
-        std::thread::sleep(std::time::Duration::from_secs(5));
-    }
-}
-
-fn cudatrace_prog() -> Result<(), gpuprobe::GpuprobeError> {
-    println!("{WELCOME_CUDATRACE_MSG}");
-
-    let mut cudatrace = gpuprobe::Gpuprobe::new()?;
-    cudatrace.attach_cudatrace_uprobes()?;
+    let opts = gpuprobe::Opts {
+        memleak: args.memleak,
+        cudatrace: args.cudatrace,
+        bandwidth_util: args.bandwidth_util,
+    };
+    let mut gpuprobe = gpuprobe::Gpuprobe::new(opts)?;
+    gpuprobe.attach_uprobes()?;
 
     loop {
-        let kernel_launches = cudatrace.get_kernel_launch_frequencies()?;
-        let num_launches = kernel_launches
-            .iter()
-            .fold(0u64, |total, (_, count)| total + count);
-
-        println!(
-            "{} `cudaLaunchKernel` calls for {} kernels",
-            num_launches,
-            kernel_launches.len()
-        );
-        kernel_launches
-            .iter()
-            .for_each(|(addr, count)| println!("\t0x{addr:x}: {count} launches"));
-
+        gpuprobe.collect_data_uprobes()?;
         println!("========================\n");
-        std::thread::sleep(std::time::Duration::from_secs(5));
-    }
-}
-
-fn bandwidth_util_prog() -> Result<(), gpuprobe::GpuprobeError> {
-    println!("{WELCOME_BANDWIDTH_UTIL_MSG}");
-
-    let mut gpuprobe = gpuprobe::Gpuprobe::new()?;
-    gpuprobe.attach_bandwidth_util_uprobes()?;
-
-    loop {
-        let calls = gpuprobe.consume_queue()?;
-
-        if calls.len() == 0 {
-            continue;
-        }
-
-        println!("Traced {} cudaMemcpy calls", calls.len());
-        calls.iter().for_each(|c| {
-            let bandwidth_util = c.compute_bandwidth_util().unwrap_or(0.0);
-            let delta = (c.end_time - c.start_time) as f64 / 1e9;
-            println!(
-                "\t{} {:.5} bytes/sec for {:.5} secs",
-                c.kind_to_str(),
-                bandwidth_util,
-                delta
-            )
-        });
-
-        println!("========================\n");
+        // !!TODO!! make this variable
         std::thread::sleep(std::time::Duration::from_secs(5));
     }
 }


### PR DESCRIPTION
this PR merges the three aforementioned programs such that they can all be executed simultaneously from a single binary.

- we can attach all relevant uprobes at once
- we can display all of their data in a single cycle

the idea is to be able to export all of this data as Prometheus metrics nicely.