### PR TITLE
Add configurable metrics endpoint and display interval (Closes #9)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ struct Args {
     bandwidth_util: bool,
 
     /// Address for the Prometheus metrics endpoint.
-    #[arg(long, default_value = "0.0.0.0:9091")]
+    #[arg(long, default_value = "0.0.0.0:9000")]
     metrics_addr: String,
 
     /// Interval in seconds for displaying metrics to stdout.


### PR DESCRIPTION
example run:
sudo ./gpu_probe --memleak --display-interval=1 --metrics-addr=127.0.0.23:8080