### PR TITLE
[Refactor] Update memleak program to process events from kernel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,6 +406,7 @@ dependencies = [
  "libbpf-cargo",
  "libbpf-rs",
  "libc",
+ "nix",
  "prometheus-client",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ prometheus-client = "0.22.3"
 axum = "0.7.7"
 tokio = { version = "1.41.0", features = ["rt-multi-thread", "macros"] }
 chrono = "0.4.38"
+nix = { version = "0.29.0", features = ["process", "signal"] }

--- a/src/bpf/gpuprobe.bpf.c
+++ b/src/bpf/gpuprobe.bpf.c
@@ -13,15 +13,14 @@ enum memleak_event_t {
  * and some metadata
  */
 struct memleak_event {
-	enum memleak_event_t event_type;
-	u32 pid;
-	u64 start;
-	u64 end;
-
+	__u64 start;
+	__u64 end;
 	void *device_addr;
+	__u64 size;
+	__u32 pid;
 	/// contains the allocation size if event_type == CUDA_MALLOC
-	size_t size;
-	int ret;
+	int32 ret;
+	enum memleak_event_t event_type;
 };
 
 /**
@@ -61,7 +60,7 @@ struct {
 SEC("uprobe/cudaMalloc")
 int memleak_cuda_malloc(struct pt_regs *ctx)
 {
-	struct memleak_event e;
+	struct memleak_event e = { 0 };
 	void **dev_ptr;
 	u32 pid, key0 = 0;
 

--- a/src/gpuprobe/gpuprobe_memleak.rs
+++ b/src/gpuprobe/gpuprobe_memleak.rs
@@ -1,68 +1,7 @@
-use std::error::Error;
+use libbpf_rs::MapCore;
 
-use libbpf_rs::{MapCore, MapFlags};
-
-use super::uprobe_data::MemleakData;
 use super::{Gpuprobe, GpuprobeError, LIBCUDART_PATH};
-use std::collections::HashMap;
-
-/// Wraps the state that is maintained by the memleak program
-pub struct MemleakProgramData {
-    allocations: HashMap<u32, MemleakEvent>,
-}
-
-impl MemleakProgramData {
-    pub fn new() -> Self {
-        return MemleakProgramData {
-            allocations: HashMap::new(),
-        };
-    }
-}
-
-struct MemleakEvent {
-    start: u64,
-    end: u64,
-    device_addr: u64,
-    size: u64,
-    pid: u32,
-    ret: i32,
-    event_type: i32,
-}
-
-impl MemleakEvent {
-    /// Constructs a MemleakEvent struct from a raw byte array and returns it,
-    /// or None if the byte array isn't correctly sized.
-    pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
-        if bytes.len() < std::mem::size_of::<Self>() {
-            return None;
-        }
-        // This is safe if:
-        // 1. The byte array contains valid data for this struct
-        // 2. The byte array is at least as large as the struct
-        unsafe { Some(std::ptr::read_unaligned(bytes.as_ptr() as *const Self)) }
-    }
-}
-
-impl std::fmt::Display for MemleakEvent {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{{\n")?;
-
-        if self.event_type == 0 {
-            write!(f, "\ttype: {}\n", "cudaMalloc")?;
-        } else if self.event_type == 1 {
-            write!(f, "\ttype: {}\n", "cudaFree")?;
-        }
-
-        write!(f, "\tsize: {}\n", self.size)?;
-        write!(f, "\tpid: {}\n", self.pid)?;
-        write!(f, "\tstart: {}\n", self.start)?;
-        write!(f, "\tend: {}\n", self.end)?;
-        write!(f, "\tdev_addr: 0x{:x}\n", self.device_addr)?;
-        write!(f, "\tret: {}\n", self.ret)?;
-
-        write!(f, "}}")
-    }
-}
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 /// contains implementation for the memleak program
 impl Gpuprobe {
@@ -108,18 +47,8 @@ impl Gpuprobe {
         Ok(())
     }
 
-    fn update_memleak_prog_data(&mut self, data: MemleakEvent) -> Result<(), GpuprobeError> {
-        if data.event_type == 0 {
-        } else if data.event_type == 1 {
-        } else {
-            return Err(GpuprobeError::RuntimeError(
-                    "invalid memleak event type".to_string()
-            ));
-        }
-        Ok(())
-    }
-
-    pub fn consume_memleak_queue(&mut self) -> Result<(), GpuprobeError> {
+    /// Consumes from the memleak event queue and updates memleak_state
+    pub fn consume_memleak_events(&mut self) -> Result<(), GpuprobeError> {
         let key: [u8; 0] = []; // key size must be zero for BPF_MAP_TYPE_QUEUE
                                // `lookup_and_delete` calls.
         while let Ok(opt) = self
@@ -131,7 +60,9 @@ impl Gpuprobe {
         {
             let event_bytes = match opt {
                 Some(b) => b,
-                None => { return Ok(()); }
+                None => {
+                    return Ok(());
+                }
             };
             let event = match MemleakEvent::from_bytes(&event_bytes) {
                 Some(e) => e,
@@ -141,32 +72,242 @@ impl Gpuprobe {
                     ));
                 }
             };
+            self.memleak_state.handle_event(event)?;
+        }
+        Ok(())
+    }
+}
 
-            println!("{}", event);
+pub struct MemleakState {
+    pub memory_map: HashMap<u32, BTreeMap<u64, CudaMemoryAlloc>>,
+    pub num_successful_mallocs: u64,
+    pub num_failed_mallocs: u64,
+    pub num_successful_frees: u64,
+    pub num_failed_frees: u64,
+    /// we use this to keep track of which processes are still alive, and
+    /// efficiently clean up terminated processes
+    active_pids: HashSet<u32>,
+}
+
+impl MemleakState {
+    pub fn new() -> Self {
+        return MemleakState {
+            memory_map: HashMap::new(),
+            num_successful_mallocs: 0u64,
+            num_failed_mallocs: 0u64,
+            num_successful_frees: 0u64,
+            num_failed_frees: 0u64,
+            active_pids: HashSet::new(),
+        };
+    }
+
+    /// Handles a MemleakEvent recorded in kernel-space and updates all state.
+    /// This includes
+    ///     - memory map update
+    ///     - number of calls for events
+    ///     - number of failures
+    fn handle_event(&mut self, data: MemleakEvent) -> Result<(), GpuprobeError> {
+        self.active_pids.insert(data.pid.clone());
+        if data.event_type == MemleakEventType::CudaMalloc as i32 {
+            if data.ret != 0 {
+                self.num_failed_mallocs += 1;
+                return Ok(());
+            } else {
+                self.num_successful_mallocs += 1;
+            }
+
+            if !self.memory_map.contains_key(&data.pid) {
+                self.memory_map.insert(data.pid, BTreeMap::new());
+            }
+
+            let memory_map = match self.memory_map.get_mut(&data.pid) {
+                Some(mm) => mm,
+                None => {
+                    todo!("should return error here");
+                }
+            };
+
+            memory_map.insert(
+                data.device_addr,
+                CudaMemoryAlloc {
+                    size: data.size,
+                    offset: data.device_addr,
+                },
+            );
+        } else if data.event_type == MemleakEventType::CudaFree as i32 {
+            if data.ret != 0 {
+                self.num_failed_frees += 1;
+                return Ok(());
+            } else {
+                self.num_successful_frees += 1;
+            }
+
+            if !self.memory_map.contains_key(&data.pid) {
+                // Freeing data that isn't allocated. This represents a problem
+                // in the user code, or in our own tracking of memory
+                // allocations. It seems reasonable to want to panic here.
+                panic!("attempt to free unallocated memory - aborting");
+            }
+
+            let memory_map = match self.memory_map.get_mut(&data.pid) {
+                Some(mm) => mm,
+                None => {
+                    todo!("should return error here");
+                }
+            };
+
+            // set the number of outsanding bytes to zero
+            memory_map.insert(
+                data.device_addr,
+                CudaMemoryAlloc {
+                    size: 0u64,
+                    offset: data.device_addr,
+                },
+            );
+        } else {
+            return Err(GpuprobeError::RuntimeError(
+                "invalid memleak event type".to_string(),
+            ));
         }
         Ok(())
     }
 
-    /// returns a map of outsanding cuda memory allocations - i.e. ones that
-    /// have not yet been freed
-    pub fn collect_data_memleak(&mut self) -> Result<MemleakData, GpuprobeError> {
-        self.consume_memleak_queue()?;
-        //let outstanding_allocs: Vec<(u64, u64)> = self
-        //    .skel
-        //    .skel
-        //    .maps
-        //    .successful_allocs
-        //    .keys()
-        //    .map(|addr| {
-        //        self.addr_to_allocation(addr)
-        //            .expect("failed to get allocation")
-        //    })
-        //    .filter(|(_, size)| size > &0)
-        //    .collect();
+    /// Cleans up the memory maps for all terminated processes. This is a
+    /// relatively expensive operation as it involves sending `kill(0)` signals
+    /// to all of the processes being monitored as an aliveness check, so it
+    /// should be used sparingly.
+    pub fn cleanup_terminated_processes(&mut self) -> Result<(), GpuprobeError> {
+        let pids: Vec<u32> = self.active_pids.clone().into_iter().collect();
+        for pid in pids {
+            if MemleakState::is_process_dead(pid.clone())? {
+                self.cleanup_single_terminated_process(pid.clone())?;
+            }
+        }
+        Ok(())
+    }
 
-        // !!TODO!! this is just for compatibility
-        Ok(MemleakData {
-            outstanding_allocs: vec![],
-        })
+    /// Cleans up the memory map for a single terminated process
+    fn cleanup_single_terminated_process(&mut self, pid: u32) -> Result<(), GpuprobeError> {
+        // we needn't clean up a processes's memory map more than once
+        if !self.active_pids.contains(&pid) {
+            return Ok(());
+        }
+
+        let memory_map = match self.memory_map.get_mut(&pid) {
+            Some(memory_map) => memory_map,
+            None => {
+                return Err(GpuprobeError::RuntimeError(
+                    "no memory map for provided pid".to_string(),
+                ));
+            }
+        };
+
+        for (_, alloc) in memory_map {
+            alloc.size = 0u64;
+        }
+
+        self.active_pids.remove(&pid);
+        Ok(())
+    }
+
+    /// Returns true iff the process has terminated
+    fn is_process_dead(pid: u32) -> Result<bool, GpuprobeError> {
+        #[cfg(target_family = "unix")]
+        {
+            use nix::sys::signal::kill;
+            use nix::unistd::Pid;
+
+            match kill(Pid::from_raw(pid as i32), None) {
+                Ok(_) => Ok(false),
+                Err(nix::errno::Errno::ESRCH) => Ok(true),
+                Err(e) => Err(GpuprobeError::RuntimeError(e.to_string())),
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for MemleakState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(
+            f,
+            "num_successful_mallocs:  {}",
+            self.num_successful_mallocs
+        )?;
+        writeln!(f, "num_failed_mallocs:      {}", self.num_failed_mallocs)?;
+        writeln!(f, "num_successful_frees:    {}", self.num_successful_frees)?;
+        writeln!(f, "num_failed_frees:        {}", self.num_failed_frees)?;
+
+        writeln!(f, "per-process memory maps:")?;
+        for (pid, b_tree_map) in self.memory_map.iter() {
+            writeln!(f, "process {}", pid)?;
+
+            for (_, alloc) in b_tree_map.iter() {
+                writeln!(f, "\t{alloc}")?;
+            }
+        }
+        writeln!(f)
+    }
+}
+
+/// Maps one-to-one with `struct memleak_event` defined `/bpf/gpuprobe.bpf.c`.
+struct MemleakEvent {
+    start: u64,
+    end: u64,
+    device_addr: u64,
+    size: u64,
+    pid: u32,
+    ret: i32,
+    event_type: i32,
+}
+
+enum MemleakEventType {
+    CudaMalloc = 0,
+    CudaFree = 1,
+}
+
+impl MemleakEvent {
+    /// Constructs a MemleakEvent struct from a raw byte array and returns it,
+    /// or None if the byte array isn't correctly sized.
+    pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() < std::mem::size_of::<Self>() {
+            return None;
+        }
+        // This is safe if:
+        // 1. The byte array contains valid data for this struct
+        // 2. The byte array is at least as large as the struct
+        unsafe { Some(std::ptr::read_unaligned(bytes.as_ptr() as *const Self)) }
+    }
+}
+
+impl std::fmt::Display for MemleakEvent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{{\n")?;
+
+        if self.event_type == 0 {
+            write!(f, "\ttype: {}\n", "cudaMalloc")?;
+        } else if self.event_type == 1 {
+            write!(f, "\ttype: {}\n", "cudaFree")?;
+        }
+
+        write!(f, "\tsize: {}\n", self.size)?;
+        write!(f, "\tpid: {}\n", self.pid)?;
+        write!(f, "\tstart: {}\n", self.start)?;
+        write!(f, "\tend: {}\n", self.end)?;
+        write!(f, "\tdev_addr: 0x{:x}\n", self.device_addr)?;
+        write!(f, "\tret: {}\n", self.ret)?;
+
+        write!(f, "}}")
+    }
+}
+
+/// wraps metadata related to a cuda memory allocation
+pub struct CudaMemoryAlloc {
+    pub size: u64,
+    pub offset: u64,
+}
+
+impl std::fmt::Display for CudaMemoryAlloc {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "0x{:016x}: {} Bytes", self.offset, self.size)
     }
 }

--- a/src/gpuprobe/gpuprobe_memleak.rs
+++ b/src/gpuprobe/gpuprobe_memleak.rs
@@ -4,6 +4,65 @@ use libbpf_rs::{MapCore, MapFlags};
 
 use super::uprobe_data::MemleakData;
 use super::{Gpuprobe, GpuprobeError, LIBCUDART_PATH};
+use std::collections::HashMap;
+
+/// Wraps the state that is maintained by the memleak program
+pub struct MemleakProgramData {
+    allocations: HashMap<u32, MemleakEvent>,
+}
+
+impl MemleakProgramData {
+    pub fn new() -> Self {
+        return MemleakProgramData {
+            allocations: HashMap::new(),
+        };
+    }
+}
+
+struct MemleakEvent {
+    start: u64,
+    end: u64,
+    device_addr: u64,
+    size: u64,
+    pid: u32,
+    ret: i32,
+    event_type: i32,
+}
+
+impl MemleakEvent {
+    /// Constructs a MemleakEvent struct from a raw byte array and returns it,
+    /// or None if the byte array isn't correctly sized.
+    pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() < std::mem::size_of::<Self>() {
+            return None;
+        }
+        // This is safe if:
+        // 1. The byte array contains valid data for this struct
+        // 2. The byte array is at least as large as the struct
+        unsafe { Some(std::ptr::read_unaligned(bytes.as_ptr() as *const Self)) }
+    }
+}
+
+impl std::fmt::Display for MemleakEvent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{{\n")?;
+
+        if self.event_type == 0 {
+            write!(f, "\ttype: {}\n", "cudaMalloc")?;
+        } else if self.event_type == 1 {
+            write!(f, "\ttype: {}\n", "cudaFree")?;
+        }
+
+        write!(f, "\tsize: {}\n", self.size)?;
+        write!(f, "\tpid: {}\n", self.pid)?;
+        write!(f, "\tstart: {}\n", self.start)?;
+        write!(f, "\tend: {}\n", self.end)?;
+        write!(f, "\tdev_addr: 0x{:x}\n", self.device_addr)?;
+        write!(f, "\tret: {}\n", self.ret)?;
+
+        write!(f, "}}")
+    }
+}
 
 /// contains implementation for the memleak program
 impl Gpuprobe {
@@ -14,7 +73,7 @@ impl Gpuprobe {
             .skel
             .skel
             .progs
-            .trace_cuda_malloc
+            .memleak_cuda_malloc
             .attach_uprobe(false, -1, LIBCUDART_PATH, 0x00000000000560c0)
             .map_err(|_| GpuprobeError::AttachError)?;
 
@@ -22,7 +81,7 @@ impl Gpuprobe {
             .skel
             .skel
             .progs
-            .trace_cuda_malloc_ret
+            .memleak_cuda_malloc_ret
             .attach_uprobe(true, -1, LIBCUDART_PATH, 0x00000000000560c0)
             .map_err(|_| GpuprobeError::AttachError)?;
 
@@ -42,54 +101,72 @@ impl Gpuprobe {
             .attach_uprobe(true, -1, LIBCUDART_PATH, 0x00000000000568c0)
             .map_err(|_| GpuprobeError::AttachError)?;
 
-        self.links.links.trace_cuda_malloc = Some(cuda_malloc_uprobe_link);
-        self.links.links.trace_cuda_malloc_ret = Some(cuda_malloc_uretprobe_link);
+        self.links.links.memleak_cuda_malloc = Some(cuda_malloc_uprobe_link);
+        self.links.links.memleak_cuda_malloc_ret = Some(cuda_malloc_uretprobe_link);
         self.links.links.trace_cuda_free = Some(cuda_free_uprobe_link);
         self.links.links.trace_cuda_free_ret = Some(cuda_free_uretprobe_link);
         Ok(())
     }
 
-    /// converts an address to its given allocation information by performing
-    /// a lookup in the map of successful allocations
-    fn addr_to_allocation(&self, addr: Vec<u8>) -> Result<(u64, u64), GpuprobeError> {
-        let addr_key: [u8; 8] = addr
-            .try_into()
-            .map_err(|_| GpuprobeError::RuntimeError("conversion error".to_string()))?;
+    fn update_memleak_prog_data(&mut self, data: MemleakEvent) -> Result<(), GpuprobeError> {
+        if data.event_type == 0 {
+        } else if data.event_type == 1 {
+        } else {
+            return Err(GpuprobeError::RuntimeError(
+                    "invalid memleak event type".to_string()
+            ));
+        }
+        Ok(())
+    }
 
-        let size_bytes = self
+    pub fn consume_memleak_queue(&mut self) -> Result<(), GpuprobeError> {
+        let key: [u8; 0] = []; // key size must be zero for BPF_MAP_TYPE_QUEUE
+                               // `lookup_and_delete` calls.
+        while let Ok(opt) = self
             .skel
             .skel
             .maps
-            .successful_allocs
-            .lookup(&addr_key, MapFlags::ANY)
-            .map_err(|_| GpuprobeError::RuntimeError("map lookup error".to_string()))?
-            .unwrap_or(u64::to_ne_bytes(0u64).to_vec());
+            .memleak_events_queue
+            .lookup_and_delete(&key)
+        {
+            let event_bytes = match opt {
+                Some(b) => b,
+                None => { return Ok(()); }
+            };
+            let event = match MemleakEvent::from_bytes(&event_bytes) {
+                Some(e) => e,
+                None => {
+                    return Err(GpuprobeError::RuntimeError(
+                        "unable to construct MemleakEvent from bytes".to_string(),
+                    ));
+                }
+            };
 
-        let size_bytes: [u8; 8] = size_bytes
-            .try_into()
-            .map_err(|_| GpuprobeError::RuntimeError("conversion error".to_string()))?;
-
-        let size = u64::from_ne_bytes(size_bytes);
-
-        Ok((u64::from_ne_bytes(addr_key), size))
+            println!("{}", event);
+        }
+        Ok(())
     }
 
     /// returns a map of outsanding cuda memory allocations - i.e. ones that
     /// have not yet been freed
     pub fn collect_data_memleak(&mut self) -> Result<MemleakData, GpuprobeError> {
-        let outstanding_allocs: Vec<(u64, u64)> = self
-            .skel
-            .skel
-            .maps
-            .successful_allocs
-            .keys()
-            .map(|addr| {
-                self.addr_to_allocation(addr)
-                    .expect("failed to get allocation")
-            })
-            .filter(|(_, size)| size > &0)
-            .collect();
+        self.consume_memleak_queue()?;
+        //let outstanding_allocs: Vec<(u64, u64)> = self
+        //    .skel
+        //    .skel
+        //    .maps
+        //    .successful_allocs
+        //    .keys()
+        //    .map(|addr| {
+        //        self.addr_to_allocation(addr)
+        //            .expect("failed to get allocation")
+        //    })
+        //    .filter(|(_, size)| size > &0)
+        //    .collect();
 
-        Ok(MemleakData { outstanding_allocs })
+        // !!TODO!! this is just for compatibility
+        Ok(MemleakData {
+            outstanding_allocs: vec![],
+        })
     }
 }

--- a/src/gpuprobe/metrics.rs
+++ b/src/gpuprobe/metrics.rs
@@ -9,12 +9,18 @@ pub struct AddrLabel {
     pub addr: u64,
 }
 
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+pub struct MemleakLabelSet {
+    pub pid: u32,
+    pub offset: u64,
+}
+
 #[derive(Debug, Clone)]
 pub struct GpuprobeMetrics {
     opts: Opts,
     // memleak metrics
     pub num_mallocs: Gauge,
-    pub memleaks: Family<AddrLabel, Gauge>,
+    pub memleaks: Family<MemleakLabelSet, Gauge>,
     // cuda trace
     pub kernel_launches: Family<AddrLabel, Gauge>,
 }

--- a/src/gpuprobe/mod.rs
+++ b/src/gpuprobe/mod.rs
@@ -21,6 +21,7 @@ mod gpuprobe {
 }
 use gpuprobe::*;
 
+use self::gpuprobe_memleak::MemleakProgramData;
 use self::metrics::AddrLabel;
 
 const LIBCUDART_PATH: &str = "/usr/local/cuda/lib64/libcudart.so";
@@ -61,6 +62,8 @@ pub struct Gpuprobe {
     links: SafeGpuprobeLinks,
     opts: Opts,
     pub metrics: GpuprobeMetrics,
+
+    memleak_data: MemleakProgramData,
 }
 
 #[derive(Clone, Debug)]
@@ -71,8 +74,8 @@ pub struct Opts {
 }
 
 const DEFAULT_LINKS: GpuprobeLinks = GpuprobeLinks {
-    trace_cuda_malloc: None,
-    trace_cuda_malloc_ret: None,
+    memleak_cuda_malloc: None,
+    memleak_cuda_malloc_ret: None,
     trace_cuda_free: None,
     trace_cuda_free_ret: None,
     trace_cuda_launch_kernel: None,
@@ -101,6 +104,7 @@ impl Gpuprobe {
             },
             opts,
             metrics,
+            memleak_data: MemleakProgramData::new(),
         })
     }
 

--- a/src/gpuprobe/uprobe_data.rs
+++ b/src/gpuprobe/uprobe_data.rs
@@ -1,13 +1,5 @@
 use super::gpuprobe_bandwidth_util::CudaMemcpy;
 
-/// defines the data that is collected in a cycle of the memleak program
-pub struct MemleakData {
-    /// a Vec of `(addr, count)` where:
-    ///     - `addr` is the virtual address (on-device) of the allocation
-    ///     - `count` is the number of bytes associated to that allocation
-    pub outstanding_allocs: Vec<(u64, u64)>,
-}
-
 /// defines the data that is collected in a cycle of the cudatrace program
 pub struct CudaTraceData {
     /// a Vec of `(addr, count)` where:
@@ -20,26 +12,6 @@ pub struct CudaTraceData {
 pub struct BandwidthUtilData {
     /// a Vec of `CudaMemcpy` calls
     pub cuda_memcpys: Vec<CudaMemcpy>,
-}
-
-impl std::fmt::Display for MemleakData {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let leaked_bytes = self
-            .outstanding_allocs
-            .iter()
-            .fold(0u64, |total, (_, size)| total + size);
-
-        writeln!(
-            f,
-            "{} bytes leaked from {} cuda memory allocation(s)",
-            leaked_bytes,
-            self.outstanding_allocs.len()
-        )?;
-
-        Ok(for (addr, size) in self.outstanding_allocs.iter() {
-            writeln!(f, "\t0x{addr:x}: {size} bytes")?;
-        })
-    }
 }
 
 impl std::fmt::Display for CudaTraceData {


### PR DESCRIPTION
This PR proposes an overhaul of how the eBPF program produces data and shares it with userspace.

- Events from the memleak uprobes are now pushed into a queue
- The Rust userspace program consumes the queue, and updates its local state based on the event. Essentially replaying the activity observed from the eBPF uprobes.

The key contribution of the PR is to reduce the work needed to be done by the eBPF compenents _(less book-keeping)_ and make the userspace code more extensible without requiring huge changes to the to the kernel-space programs.

Another major update is the ability to maintain per-process memory maps of the GPUs virtual address space _(which has a different base for every process, sort of like ASLR)_. Example:

```
2024-11-27 15:23:29

num_successful_mallocs:  6
num_failed_mallocs:      0
num_successful_frees:    2
num_failed_frees:        0
per-process memory maps:
process 285770
        0x000077176c000000: 8000000 Bytes
process 324826
        0x000076ac78000000: 8000000 Bytes
        0x000076ac7cc00000: 8000000 Bytes
        0x000076ac7d400000: 8000000 Bytes
```

The per-process memory maps are stored as B-trees to maintain address ordering with fast lookup / update times.

This PR also proposes cleanups of per-process memory maps when a process terminates, so that we no longer report leaked memory usage for a leaked program. This is done by zeroing out all allocations, which is a temporary solution until we find something more robust that also works with Prometheus exporting _(i.e. we need to clear the Prometheus gauge metrics)_.